### PR TITLE
SmartPortOrder: Finished all combinations and smartHelper

### DIFF
--- a/src/Renderer/DrawBlock/SmartHelpers.fs
+++ b/src/Renderer/DrawBlock/SmartHelpers.fs
@@ -162,4 +162,14 @@ let getSymbolIndex (symbol: Symbol) (portId: string) =
 
     symbol.PortMaps.Order[edge]
     |> List.findIndex (fun elm -> elm = portId)
+
+
+/// HLP23: Indraneel
+/// Returns a symbol option given a model an inputPort/outputPort
+let getSymbol (wModel: BusWireT.Model) (portId: string) = 
+    let inputPortHostId = string wModel.Symbol.Ports[portId].HostId
+
+    wModel.Symbol.Symbols
+    |> Map.tryFind (ComponentId inputPortHostId)
+
   

--- a/src/Renderer/DrawBlock/SmartHelpers.fs
+++ b/src/Renderer/DrawBlock/SmartHelpers.fs
@@ -154,3 +154,12 @@ let findInterconnectingWires (wireList:List<Wire>) (sModel)
             else false
 
         )
+
+/// HLP23: Indraneel
+/// Returns the symbol index given symbol and portId
+let getSymbolIndex (symbol: Symbol) (portId: string) = 
+    let edge = symbol.PortMaps.Orientation[portId]
+
+    symbol.PortMaps.Order[edge]
+    |> List.findIndex (fun elm -> elm = portId)
+  


### PR DESCRIPTION
Completed SmarPortOrder all combinations such as bottom/right. Added 2 smart helpers `getSymbol` and `getSymbolIndex`